### PR TITLE
Pin third-party GitHub Actions to SHAs and update Codecov

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
           go-version: '>=1.18'
       - run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
           go-version: '>=1.18'
       - run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with pinned commits.
- Updated Codecov to the current v6 action before pinning it.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/run-tests.yml`

Resolved refs:

- `codecov/codecov-action@v3` -> `codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows

Follow-up update:

- `codecov/codecov-action@v3` now resolves through the v6 commit `codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f`.
